### PR TITLE
fix(scan): extend dedup cache window from 5 min to 24 h

### DIFF
--- a/apps/web/src/app/api/scan/route.ts
+++ b/apps/web/src/app/api/scan/route.ts
@@ -45,7 +45,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Invalid owner or repo name' }, { status: 400 });
   }
 
-  const fiveMinAgo = new Date(Date.now() - 5 * 60_000);
+  const cacheCutoff = new Date(Date.now() - 24 * 60 * 60_000);
   const [recent] = await db
     .select()
     .from(scans)
@@ -54,7 +54,7 @@ export async function POST(request: Request) {
         eq(scans.repoOwner, info.owner),
         eq(scans.repoName, info.repo),
         eq(scans.status, 'complete'),
-        gt(scans.createdAt, fiveMinAgo),
+        gt(scans.createdAt, cacheCutoff),
       ),
     )
     .orderBy(desc(scans.createdAt))


### PR DESCRIPTION
Closes #14.

## Summary

- `/api/scan` cached result window: 5 minutes → 24 hours.
- Rescans within 24 h return the existing row; rescans after 24 h still insert a fresh one (history preserved).

## Why

Downstream views (`/r/[owner]/[repo]` page, OG/Twitter images, badge) already `ORDER BY created_at DESC LIMIT 1` filtered to `status='complete'`, so stale duplicates are invisible to users but bloat the `scans` table and skew `/api/scan/count`. Issue #14 has the full rationale.

## Test plan

- [ ] `pnpm turbo typecheck` passes
- [ ] `pnpm turbo build` passes
- [ ] `pnpm turbo test` passes (no tests reference the 5-min constant)
- [ ] Manual: POST `/api/scan` twice within an hour for the same repo → second request returns `cached: true`, no new row in DB
- [ ] Manual: same POST 25h later → new row inserted, `cached` absent