### PR TITLE
fix(scan-count): count unique successful repos, not total rows

### DIFF
--- a/apps/web/src/app/api/scan/count/route.ts
+++ b/apps/web/src/app/api/scan/count/route.ts
@@ -1,10 +1,13 @@
 import { db } from '@repo/shared/db';
 import { scans } from '@repo/shared/db/schema';
-import { count } from 'drizzle-orm';
+import { countDistinct, eq, sql } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
 
 export async function GET() {
-  const [result] = await db.select({ count: count() }).from(scans);
+  const [result] = await db
+    .select({ count: countDistinct(sql`(${scans.repoOwner}, ${scans.repoName})`) })
+    .from(scans)
+    .where(eq(scans.status, 'complete'));
   return NextResponse.json(
     { count: result.count },
     { headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600' } },


### PR DESCRIPTION
Closes #15.

## Summary

- `/api/scan/count` now returns `COUNT(DISTINCT (repo_owner, repo_name))` filtered to `status='complete'`.
- Failed/stuck/duplicate rows no longer inflate the public count.

## Why

`COUNT(*)` over the full `scans` table included:
- Failed validation probes (e.g. `etc/passwd` fuzzing attempts)
- Stuck `scanning` rows from serverless timeouts
- Multiple `complete` rows per repo from repeated requests

The new query returns the meaningful metric: number of unique repos with at least one successful scan. Issue #15 has the rationale.

## Test plan

- [ ] `pnpm turbo typecheck` passes
- [ ] `pnpm turbo build` passes
- [ ] `pnpm turbo test` passes
- [ ] Manual: hit `/api/scan/count` on a DB with a mix of failed + duplicate rows → count reflects distinct completed repos only
- [ ] SQL parity: query matches `SELECT count(distinct (repo_owner, repo_name)) FROM scans WHERE status = 'complete';`