### PR TITLE
feat(scan): log client IP on validation failures

### DIFF
--- a/apps/web/src/app/api/scan/route.ts
+++ b/apps/web/src/app/api/scan/route.ts
@@ -13,6 +13,9 @@ export const maxDuration = 60;
 const SCANNER_URL = process.env.SCANNER_BACKEND_URL;
 const SCAN_SECRET = process.env.SCAN_SECRET || '';
 
+// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping control chars is the point
+const sanitize = (s: string) => s.replace(/[\x00-\x1f\x7f]/g, '').slice(0, 256);
+
 export async function POST(request: Request) {
   const headersList = await headers();
   const ip = headersList.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
@@ -40,12 +43,16 @@ export async function POST(request: Request) {
 
   const info = parseGitHubUrl(url);
   if (!info) {
-    console.warn('[scan] rejected', { ip, url, reason: 'invalid-url' });
+    console.warn('[scan] rejected', { ip, url: sanitize(url), reason: 'invalid-url' });
     return NextResponse.json({ error: 'Invalid GitHub URL' }, { status: 400 });
   }
 
   if (!isValidRepoName(info.owner) || !isValidRepoName(info.repo)) {
-    console.warn('[scan] rejected', { ip, url, reason: 'invalid-name' });
+    console.warn('[scan] rejected', {
+      ip,
+      repo: `${sanitize(info.owner)}/${sanitize(info.repo)}`,
+      reason: 'invalid-name',
+    });
     return NextResponse.json({ error: 'Invalid owner or repo name' }, { status: 400 });
   }
 

--- a/apps/web/src/app/api/scan/route.ts
+++ b/apps/web/src/app/api/scan/route.ts
@@ -28,20 +28,24 @@ export async function POST(request: Request) {
   try {
     body = await request.json();
   } catch {
+    console.warn('[scan] rejected', { ip, reason: 'invalid-json' });
     return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
   }
 
   const { url } = body;
   if (!url || typeof url !== 'string') {
+    console.warn('[scan] rejected', { ip, reason: 'missing-url' });
     return NextResponse.json({ error: 'URL is required' }, { status: 400 });
   }
 
   const info = parseGitHubUrl(url);
   if (!info) {
+    console.warn('[scan] rejected', { ip, url, reason: 'invalid-url' });
     return NextResponse.json({ error: 'Invalid GitHub URL' }, { status: 400 });
   }
 
   if (!isValidRepoName(info.owner) || !isValidRepoName(info.repo)) {
+    console.warn('[scan] rejected', { ip, url, reason: 'invalid-name' });
     return NextResponse.json({ error: 'Invalid owner or repo name' }, { status: 400 });
   }
 


### PR DESCRIPTION
Closes #16.

## Summary

- Add `console.warn` at each 400-return branch in `/api/scan` — JSON parse failure, missing URL, invalid URL, invalid owner/repo name.
- Logs include the client IP (already computed for rate-limiting), the offending URL where available, and a short reason code.

## Why

Validation failures were previously invisible — Vercel request logs show only status codes, not payloads or IPs. Probing bursts (e.g. `etc/passwd`) were impossible to attribute without a log drain. A one-line `console.warn` per branch is enough because Vercel surfaces it in runtime logs.

## Test plan

- [ ] `pnpm turbo typecheck` passes
- [ ] `pnpm turbo build` passes
- [ ] `pnpm turbo test` passes
- [ ] Manual: POST malformed JSON, missing URL, `{"url":"https://example.com/foo/bar"}`, `{"url":"https://github.com/etc/passwd"}` (wait — that passes validation) — each bad variant should produce a tagged `[scan] rejected` line in `vercel logs`.