### PR TITLE
fix(scan): mark stale 'scanning' rows as failed before new insert

### DIFF
--- a/apps/web/src/app/api/scan/route.ts
+++ b/apps/web/src/app/api/scan/route.ts
@@ -2,7 +2,7 @@ import { db } from '@repo/shared/db';
 import { scans } from '@repo/shared/db/schema';
 import { parseGitHubUrl } from '@repo/shared/github';
 import { isValidRepoName } from '@repo/shared/validation';
-import { and, desc, eq, gt, lt } from 'drizzle-orm';
+import { and, desc, eq, gt, sql } from 'drizzle-orm';
 import { headers } from 'next/headers';
 import { NextResponse } from 'next/server';
 import { rateLimit } from '@/lib/rate-limit';
@@ -75,7 +75,6 @@ export async function POST(request: Request) {
     );
   }
 
-  const stuckCutoff = new Date(Date.now() - 10 * 60_000);
   await db
     .update(scans)
     .set({ status: 'failed' })
@@ -84,7 +83,7 @@ export async function POST(request: Request) {
         eq(scans.repoOwner, info.owner),
         eq(scans.repoName, info.repo),
         eq(scans.status, 'scanning'),
-        lt(scans.createdAt, stuckCutoff),
+        sql`${scans.createdAt} < now() - interval '10 minutes'`,
       ),
     );
 

--- a/apps/web/src/app/api/scan/route.ts
+++ b/apps/web/src/app/api/scan/route.ts
@@ -2,7 +2,7 @@ import { db } from '@repo/shared/db';
 import { scans } from '@repo/shared/db/schema';
 import { parseGitHubUrl } from '@repo/shared/github';
 import { isValidRepoName } from '@repo/shared/validation';
-import { and, desc, eq, gt } from 'drizzle-orm';
+import { and, desc, eq, gt, lt } from 'drizzle-orm';
 import { headers } from 'next/headers';
 import { NextResponse } from 'next/server';
 import { rateLimit } from '@/lib/rate-limit';
@@ -74,6 +74,19 @@ export async function POST(request: Request) {
       { headers: { 'X-RateLimit-Remaining': String(remaining) } },
     );
   }
+
+  const stuckCutoff = new Date(Date.now() - 10 * 60_000);
+  await db
+    .update(scans)
+    .set({ status: 'failed' })
+    .where(
+      and(
+        eq(scans.repoOwner, info.owner),
+        eq(scans.repoName, info.repo),
+        eq(scans.status, 'scanning'),
+        lt(scans.createdAt, stuckCutoff),
+      ),
+    );
 
   const [scan] = await db
     .insert(scans)


### PR DESCRIPTION
Closes #17.

## Summary

- Before inserting a new scan row for `(owner, repo)`, run an UPDATE that marks any existing `status='scanning'` rows for the same repo older than **10 minutes** as `failed`.
- Piggybacks cleanup on the next legitimate scan request — no cron job needed.

## Why

If a Vercel serverless invocation is killed mid-scan (60s `maxDuration` with the built-in scanner, or a dropped connection to the Railway backend), the row stays in `scanning` forever. Minimal user impact because the report page filters to `status='complete'`, but these rows clutter the table and future admin/debug tooling.

10 minutes is a safe threshold: Vercel `maxDuration` is 60s and the Railway backend finishes in seconds for typical repos.

## Test plan

- [ ] `pnpm turbo typecheck` passes
- [ ] `pnpm turbo build` passes
- [ ] `pnpm turbo test` passes
- [ ] Manual: insert a `scanning` row dated >10 min ago, POST `/api/scan` for the same repo, verify the old row flipped to `failed` and a fresh `scanning` row exists.