### PR TITLE
perf(scans): add compound index on (repo_owner, repo_name, status, created_at DESC)

### DIFF
--- a/apps/web/drizzle/0001_scans_repo_status_created_idx.sql
+++ b/apps/web/drizzle/0001_scans_repo_status_created_idx.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "scans_repo_status_created_idx" ON "scans" USING btree ("repo_owner","repo_name","status","created_at" DESC NULLS LAST);

--- a/apps/web/drizzle/meta/0001_snapshot.json
+++ b/apps/web/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,242 @@
+{
+  "id": "f42fceb2-8bca-49ff-bd2b-72684d312ac8",
+  "prevId": "84766c46-6505-44cd-8613-93caf919665f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.findings": {
+      "name": "findings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_name": {
+          "name": "check_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "findings_scan_id_scans_id_fk": {
+          "name": "findings_scan_id_scans_id_fk",
+          "tableFrom": "findings",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scans": {
+      "name": "scans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "scan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "grade",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "findings_count": {
+          "name": "findings_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "scans_repo_status_created_idx": {
+          "name": "scans_repo_status_created_idx",
+          "columns": [
+            {
+              "expression": "repo_owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.grade": {
+      "name": "grade",
+      "schema": "public",
+      "values": [
+        "A",
+        "B",
+        "C",
+        "D",
+        "F"
+      ]
+    },
+    "public.scan_status": {
+      "name": "scan_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "scanning",
+        "complete",
+        "failed"
+      ]
+    },
+    "public.severity": {
+      "name": "severity",
+      "schema": "public",
+      "values": [
+        "critical",
+        "high",
+        "medium",
+        "low",
+        "info"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1775204386399,
       "tag": "0000_goofy_sally_floyd",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1777050100532,
+      "tag": "0001_scans_repo_status_created_idx",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/shared/src/db/schema-core.ts
+++ b/packages/shared/src/db/schema-core.ts
@@ -1,4 +1,4 @@
-import { integer, pgEnum, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+import { index, integer, pgEnum, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
 
 // --- Scan tables ---
 
@@ -6,18 +6,24 @@ export const scanStatusEnum = pgEnum('scan_status', ['pending', 'scanning', 'com
 export const severityEnum = pgEnum('severity', ['critical', 'high', 'medium', 'low', 'info']);
 export const gradeEnum = pgEnum('grade', ['A', 'B', 'C', 'D', 'F']);
 
-export const scans = pgTable('scans', {
-  id: uuid('id').defaultRandom().primaryKey(),
-  repoOwner: text('repo_owner').notNull(),
-  repoName: text('repo_name').notNull(),
-  repoUrl: text('repo_url').notNull(),
-  status: scanStatusEnum('status').notNull().default('pending'),
-  score: integer('score'),
-  grade: gradeEnum('grade'),
-  findingsCount: integer('findings_count').default(0),
-  createdAt: timestamp('created_at').defaultNow().notNull(),
-  completedAt: timestamp('completed_at'),
-});
+export const scans = pgTable(
+  'scans',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    repoOwner: text('repo_owner').notNull(),
+    repoName: text('repo_name').notNull(),
+    repoUrl: text('repo_url').notNull(),
+    status: scanStatusEnum('status').notNull().default('pending'),
+    score: integer('score'),
+    grade: gradeEnum('grade'),
+    findingsCount: integer('findings_count').default(0),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    completedAt: timestamp('completed_at'),
+  },
+  (t) => [
+    index('scans_repo_status_created_idx').on(t.repoOwner.asc(), t.repoName.asc(), t.status.asc(), t.createdAt.desc()),
+  ],
+);
 
 export const findings = pgTable('findings', {
   id: uuid('id').defaultRandom().primaryKey(),


### PR DESCRIPTION
Closes #22.

## Summary

- Adds a btree index on `scans (repo_owner, repo_name, status, created_at DESC)`.
- Matches the exact predicate + ORDER BY of the two hot queries in `/api/scan`: 24h cached-result lookup and stale-scan cleanup.

## Changes

- `packages/shared/src/db/schema-core.ts` — index declaration on the `scans` table.
- `apps/web/drizzle/0001_scans_repo_status_created_idx.sql` — generated migration.
- `apps/web/drizzle/meta/{_journal.json,0001_snapshot.json}` — Drizzle metadata.

## Migration output

```sql
CREATE INDEX "scans_repo_status_created_idx" ON "scans"
  USING btree ("repo_owner","repo_name","status","created_at" DESC NULLS LAST);
```

## Deploy

After merge, run from `apps/web`:

```bash
pnpm db:migrate
```

Safe to run on a live DB — index creation on a small table is near-instant; Postgres locks briefly (no ACCESS EXCLUSIVE beyond the index build). If the table ever grows past the "briefly" threshold, a separate PR can switch this to `CREATE INDEX CONCURRENTLY` via `.concurrently()` on the Drizzle declaration.

## Test plan

- [ ] `pnpm turbo typecheck` passes
- [ ] `pnpm turbo build` passes
- [ ] `pnpm turbo test` passes
- [ ] `pnpm db:migrate` applies cleanly on a dev DB
- [ ] `EXPLAIN` on the cached-result SELECT and stale-scan UPDATE confirms the new index is used (once the table is large enough for the planner to prefer it over seq scan)