### PR TITLE
chore(drizzle): fail loudly when DATABASE_URL is missing + document migrate workflow

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -2,23 +2,25 @@
 
 Next.js App Router frontend for git.exposed. Deployed to Vercel.
 
+> All `pnpm db:*` scripts below live in `apps/web/package.json`. Run them from `apps/web` (or invoke via `pnpm --filter @repo/web <script>` from repo root).
+
 ## Local development
 
 Needs a Postgres instance. The simplest path:
 
 ```bash
-# From repo root
+# From repo root — start a local Postgres container
 docker run --name gitexposed-pg -e POSTGRES_USER=gitexposed -e POSTGRES_PASSWORD=gitexposed \
   -e POSTGRES_DB=gitexposed -p 5433:5432 -d postgres:17
 
-# In apps/web/.env
+# Point apps/web at it
 echo "DATABASE_URL=postgresql://gitexposed:gitexposed@localhost:5433/gitexposed" >> apps/web/.env
 
 # Apply schema
-pnpm db:migrate
+pnpm --filter @repo/web db:migrate
 ```
 
-Then `pnpm dev` from repo root.
+Then `pnpm turbo dev` from repo root.
 
 ## Database migrations
 
@@ -26,10 +28,10 @@ Migration files live in `apps/web/drizzle/` and are tracked by `drizzle-kit` in 
 
 ### Workflow
 
-1. Change the schema in `packages/shared/src/db/schema-core.ts` (or `schema.ts` for pro-only tables).
+1. Change the schema in `packages/shared/src/db/schema-core.ts`.
 2. Generate a migration file:
    ```bash
-   pnpm db:generate --name=<short_description>
+   pnpm --filter @repo/web db:generate --name=<short_description>
    ```
 3. Commit both the schema change and the generated `*.sql` + `meta/*.json` files.
 4. Apply to the target database (see below).
@@ -37,23 +39,26 @@ Migration files live in `apps/web/drizzle/` and are tracked by `drizzle-kit` in 
 ### Applying to local dev
 
 ```bash
-pnpm db:migrate
+pnpm --filter @repo/web db:migrate
 ```
 
 Uses `apps/web/.env`'s `DATABASE_URL`.
 
 ### Applying to production
 
-`drizzle-kit migrate` needs the **prod** `DATABASE_URL`. The safest pattern is to pull it from your host and run the migrator with Node's native `--env-file` flag so the var never ends up in a committed file:
+`drizzle-kit migrate` needs the **prod** `DATABASE_URL`. The safest pattern is to pull it from your host and run the migrator with an explicit env file so the var never ends up in a committed file:
 
 ```bash
-# From apps/web:
+cd apps/web
 vercel env pull .env.production.local --environment=production
 node --env-file=.env.production.local node_modules/.bin/drizzle-kit migrate
 rm .env.production.local
 ```
 
 `.env*.local` is gitignored. The migrator is idempotent — re-running it is a no-op once the latest migration is recorded in `__drizzle_migrations`.
+
+> `node --env-file=` requires Node 20.6+. On older Node 20.x, use a dotenv runner instead:
+> `pnpm dlx dotenv-cli -e .env.production.local -- drizzle-kit migrate`
 
 ### If `__drizzle_migrations` is out of sync
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,0 +1,72 @@
+# @repo/web
+
+Next.js App Router frontend for git.exposed. Deployed to Vercel.
+
+## Local development
+
+Needs a Postgres instance. The simplest path:
+
+```bash
+# From repo root
+docker run --name gitexposed-pg -e POSTGRES_USER=gitexposed -e POSTGRES_PASSWORD=gitexposed \
+  -e POSTGRES_DB=gitexposed -p 5433:5432 -d postgres:17
+
+# In apps/web/.env
+echo "DATABASE_URL=postgresql://gitexposed:gitexposed@localhost:5433/gitexposed" >> apps/web/.env
+
+# Apply schema
+pnpm db:migrate
+```
+
+Then `pnpm dev` from repo root.
+
+## Database migrations
+
+Migration files live in `apps/web/drizzle/` and are tracked by `drizzle-kit` in the `drizzle.__drizzle_migrations` table on the target DB.
+
+### Workflow
+
+1. Change the schema in `packages/shared/src/db/schema-core.ts` (or `schema.ts` for pro-only tables).
+2. Generate a migration file:
+   ```bash
+   pnpm db:generate --name=<short_description>
+   ```
+3. Commit both the schema change and the generated `*.sql` + `meta/*.json` files.
+4. Apply to the target database (see below).
+
+### Applying to local dev
+
+```bash
+pnpm db:migrate
+```
+
+Uses `apps/web/.env`'s `DATABASE_URL`.
+
+### Applying to production
+
+`drizzle-kit migrate` needs the **prod** `DATABASE_URL`. The safest pattern is to pull it from your host and run the migrator with Node's native `--env-file` flag so the var never ends up in a committed file:
+
+```bash
+# From apps/web:
+vercel env pull .env.production.local --environment=production
+node --env-file=.env.production.local node_modules/.bin/drizzle-kit migrate
+rm .env.production.local
+```
+
+`.env*.local` is gitignored. The migrator is idempotent — re-running it is a no-op once the latest migration is recorded in `__drizzle_migrations`.
+
+### If `__drizzle_migrations` is out of sync
+
+If the schema was bootstrapped some other way (e.g. `drizzle-kit push` or hand-run SQL), the tracking table may be empty or incomplete. Back-fill it with one row per already-applied migration before running `migrate`:
+
+```ts
+// Compute hash the same way drizzle-orm does:
+// crypto.createHash('sha256').update(fs.readFileSync('apps/web/drizzle/<tag>.sql').toString()).digest('hex')
+// `created_at` = the `when` value from meta/_journal.json for that entry
+```
+
+```sql
+INSERT INTO drizzle.__drizzle_migrations (hash, created_at) VALUES
+  ('<sha256-of-0000.sql>', <when-from-journal>),
+  ('<sha256-of-0001.sql>', <when-from-journal>);
+```

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -56,7 +56,7 @@ node --env-file=.env.production.local node_modules/.bin/drizzle-kit migrate
 rm .env.production.local
 ```
 
-`.env*.local` is gitignored. The migrator is idempotent — re-running it is a no-op once the latest migration is recorded in `__drizzle_migrations`.
+`.env*` is gitignored (except `.env.example`). The migrator is idempotent — re-running it is a no-op once the latest migration is recorded in `__drizzle_migrations`.
 
 > `node --env-file=` requires Node 20.6+. On older Node 20.x, use a dotenv runner instead:
 > `pnpm dlx dotenv-cli -e .env.production.local -- drizzle-kit migrate`

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -8,19 +8,20 @@ Next.js App Router frontend for git.exposed. Deployed to Vercel.
 
 Needs a Postgres instance. The simplest path:
 
-```bash
-# From repo root — start a local Postgres container
-docker run --name gitexposed-pg -e POSTGRES_USER=gitexposed -e POSTGRES_PASSWORD=gitexposed \
-  -e POSTGRES_DB=gitexposed -p 5433:5432 -d postgres:17
-
-# Point apps/web at it
-echo "DATABASE_URL=postgresql://gitexposed:gitexposed@localhost:5433/gitexposed" >> apps/web/.env
-
-# Apply schema
-pnpm --filter @repo/web db:migrate
-```
-
-Then `pnpm turbo dev` from repo root.
+1. Start a local Postgres container (from repo root):
+   ```bash
+   docker run --name gitexposed-pg -e POSTGRES_USER=gitexposed -e POSTGRES_PASSWORD=gitexposed \
+     -e POSTGRES_DB=gitexposed -p 5433:5432 -d postgres:17
+   ```
+2. Create or edit `apps/web/.env` and set:
+   ```
+   DATABASE_URL=postgresql://gitexposed:gitexposed@localhost:5433/gitexposed
+   ```
+3. Apply schema:
+   ```bash
+   pnpm --filter @repo/web db:migrate
+   ```
+4. Start the dev server: `pnpm turbo dev` from repo root.
 
 ## Database migrations
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -63,12 +63,12 @@ rm .env.production.local
 
 ### If `__drizzle_migrations` is out of sync
 
-If the schema was bootstrapped some other way (e.g. `drizzle-kit push` or hand-run SQL), the tracking table may be empty or incomplete. Back-fill it with one row per already-applied migration before running `migrate`:
+If the schema was bootstrapped some other way (e.g. `drizzle-kit push` or hand-run SQL), the tracking table may be empty or incomplete. Back-fill it with one row per already-applied migration before running `migrate`. From `apps/web`:
 
 ```ts
 // Compute hash the same way drizzle-orm does:
-// crypto.createHash('sha256').update(fs.readFileSync('apps/web/drizzle/<tag>.sql').toString()).digest('hex')
-// `created_at` = the `when` value from meta/_journal.json for that entry
+// crypto.createHash('sha256').update(fs.readFileSync('drizzle/<tag>.sql').toString()).digest('hex')
+// `created_at` = the `when` value from drizzle/meta/_journal.json for that entry
 ```
 
 ```sql

--- a/apps/web/drizzle.config.ts
+++ b/apps/web/drizzle.config.ts
@@ -4,8 +4,9 @@ const databaseUrl = process.env.DATABASE_URL;
 if (!databaseUrl) {
   throw new Error(
     'DATABASE_URL is not set. For local dev, put it in apps/web/.env. For prod, ' +
-      'pull it from your host (e.g. `vercel env pull .env.production.local`) and run with ' +
-      '`node --env-file=.env.production.local node_modules/.bin/drizzle-kit migrate` from apps/web.',
+      'pull it from your host (e.g. `vercel env pull .env.production.local --environment=production`) ' +
+      'and run with `node --env-file=.env.production.local node_modules/.bin/drizzle-kit migrate` ' +
+      'from apps/web (requires Node 20.6+).',
   );
 }
 

--- a/apps/web/drizzle.config.ts
+++ b/apps/web/drizzle.config.ts
@@ -1,10 +1,19 @@
 import { defineConfig } from 'drizzle-kit';
 
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) {
+  throw new Error(
+    'DATABASE_URL is not set. For local dev, put it in apps/web/.env. For prod, ' +
+      'pull it from your host (e.g. `vercel env pull .env.production.local`) and run with ' +
+      '`node --env-file=.env.production.local node_modules/.bin/drizzle-kit migrate` from apps/web.',
+  );
+}
+
 export default defineConfig({
   schema: '../../packages/shared/src/db/schema.ts',
   out: './drizzle',
   dialect: 'postgresql',
   dbCredentials: {
-    url: process.env.DATABASE_URL!,
+    url: databaseUrl,
   },
 });

--- a/apps/web/drizzle.config.ts
+++ b/apps/web/drizzle.config.ts
@@ -1,7 +1,12 @@
 import { defineConfig } from 'drizzle-kit';
 
+// Commands that need to connect to the DB. `generate`, `check`, `up`, `drop`
+// are file-only and don't need DATABASE_URL.
+const CONNECTION_COMMANDS = new Set(['migrate', 'push', 'pull', 'studio', 'introspect']);
+const needsConnection = process.argv.some((arg) => CONNECTION_COMMANDS.has(arg));
+
 const databaseUrl = process.env.DATABASE_URL;
-if (!databaseUrl) {
+if (needsConnection && !databaseUrl) {
   throw new Error(
     'DATABASE_URL is not set. For local dev, put it in apps/web/.env. For prod, ' +
       'pull it from your host (e.g. `vercel env pull .env.production.local --environment=production`) ' +
@@ -15,6 +20,6 @@ export default defineConfig({
   out: './drizzle',
   dialect: 'postgresql',
   dbCredentials: {
-    url: databaseUrl,
+    url: databaseUrl ?? '',
   },
 });


### PR DESCRIPTION
Closes #24.

## Context

Part 1 of #24 — back-filling `drizzle.__drizzle_migrations` for the existing production DB — has been done out of band (the tracking table now has rows for `0000_goofy_sally_floyd` and `0001_scans_repo_status_created_idx`, verified by a follow-up `drizzle-kit migrate` run that completed with zero new statements applied). This PR addresses part 2: the workflow gap that caused us to apply #23 manually in the first place.

## Summary

- `drizzle.config.ts`: throw an explicit error when `DATABASE_URL` is missing, with an actionable message. Drop the `!` non-null assertion that was making a missing var silently fall through to the driver.
- `apps/web/README.md` (new): document the local-dev + prod migrate workflows, including the `vercel env pull` pattern and a note on what to do if `__drizzle_migrations` drifts out of sync with the file system.

## Why

When `DATABASE_URL` was unset, `drizzle-kit migrate` would pass `undefined` to the driver and hang on the "applying migrations..." spinner instead of erroring. No feedback, no exit. The fake non-null assertion didn't help.

The README gives anyone running the migrator an explicit, copy-pasteable path for both dev and prod so the next person doesn't end up staring at a silent spinner.

## Test plan

- [x] `pnpm turbo typecheck` passes
- [x] `pnpm turbo test` passes
- [x] `env -u DATABASE_URL node node_modules/.bin/drizzle-kit migrate` prints the guard message and exits non-zero
- [ ] `pnpm db:migrate` against a dev DB still works unchanged

## Out of scope

- A Vercel-specific convenience script (`db:migrate:prod` etc.). Kept this repo deployment-agnostic; the README walks through the pattern.